### PR TITLE
chore: set release please type to go

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,8 @@
       "prerelease": true,
       "extra-files": [
         "Taskfile.yml"
-      ]
+      ],
+      "release-type": "go"
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
chore: set release please type to go

By default node is used, this expects a package.json file which this repo does not have.

https://github.com/googleapis/release-please/blob/main/docs/customizing.md
